### PR TITLE
Fix omv-snapraid-diff with DEL_THRESHOLD=0

### DIFF
--- a/usr/local/bin/omv-snapraid-diff
+++ b/usr/local/bin/omv-snapraid-diff
@@ -364,8 +364,8 @@ _log "INFO: Added: [$ADD_COUNT] - Deleted: [$DEL_COUNT] - Moved: [$MOVE_COUNT] -
 # check if files have changed
 if [ $DEL_COUNT -gt 0 -o $ADD_COUNT -gt 0 -o $MOVE_COUNT -gt 0 -o $COPY_COUNT -gt 0 -o $UPDATE_COUNT -gt 0 ]; then
 
-    # YES, check if number of deleted files exceed DEL_THRESHOLD
-    if [ $DEL_COUNT -gt $DEL_THRESHOLD ]; then
+    # YES, check if number of deleted files exceed DEL_THRESHOLD and DEL_THRESHOLD is enabled
+    if [ $DEL_COUNT -gt $DEL_THRESHOLD && $DEL_THRESHOLD -gt 0 ]; then
     
         # YES, lets inform user and not proceed with the sync just in case
         _log "INFO: Number of deleted files ($DEL_COUNT) exceeded threshold ($DEL_THRESHOLD). NOT proceeding with sync job."
@@ -378,10 +378,19 @@ if [ $DEL_COUNT -gt 0 -o $ADD_COUNT -gt 0 -o $MOVE_COUNT -gt 0 -o $COPY_COUNT -g
     else
 
         # NO, delete threshold not reached, lets run the sync job
-        _log "INFO: Changes detected [A-$ADD_COUNT,D-$DEL_COUNT,M-$MOVE_COUNT,C-$COPY_COUNT,U-$UPDATE_COUNT] -> deleted files ($DEL_COUNT) is below threshold ($DEL_THRESHOLD). Running SYNC Command."
+
+	if [ $DEL_THRESHOLD -gt 0 ] ; then
+	        # There is a DEL_THRESHOLD set, so we're informing the user that the DEL_COUNT is below it
+		_log "INFO: Changes detected [A-$ADD_COUNT,D-$DEL_COUNT,M-$MOVE_COUNT,C-$COPY_COUNT,U-$UPDATE_COUNT] -> deleted files ($DEL_COUN
+T) is below threshold ($DEL_THRESHOLD). Running SYNC Command."
 		echo "Changes detected [A-$ADD_COUNT,D-$DEL_COUNT,M-$MOVE_COUNT,C-$COPY_COUNT,U-$UPDATE_COUNT] -> deleted files ($DEL_COUNT) is below threshold ($DEL_THRESHOLD). Running SYNC Command" >> $TMP_OUTPUT
+	else
+	        # DEL_THRESHOLD is disabled, so we reflect this information in email and log
+		_log "INFO: Changes detected [A-$ADD_COUNT,D-$DEL_COUNT,M-$MOVE_COUNT,C-$COPY_COUNT,U-$UPDATE_COUNT] -> there are deltted files ($DEL_COUNT) but delete threshold ($DEL_THRESHOLD) is disabled. Running SYNC Command."
+		echo "Changes detected [A-$ADD_COUNT,D-$DEL_COUNT,M-$MOVE_COUNT,C-$COPY_COUNT,U-$UPDATE_COUNT] -> there are deleted files ($DEL_COUNT)  but delete threshold ($DEL_THRESHOLD) is disabled. Running SYNC Command" >> $TMP_OUTPUT
+	fi
 	
-		# start snapraid SYNC
+	# start snapraid SYNC
         _log "INFO: SnapRAID SYNC Job started"
         _log "INFO: ----------------------------------------"
 		echo "SnapRAID SYNC Job started - $(date)" >> $TMP_OUTPUT

--- a/usr/local/bin/omv-snapraid-diff
+++ b/usr/local/bin/omv-snapraid-diff
@@ -386,8 +386,8 @@ T) is below threshold ($DEL_THRESHOLD). Running SYNC Command."
 		echo "Changes detected [A-$ADD_COUNT,D-$DEL_COUNT,M-$MOVE_COUNT,C-$COPY_COUNT,U-$UPDATE_COUNT] -> deleted files ($DEL_COUNT) is below threshold ($DEL_THRESHOLD). Running SYNC Command" >> $TMP_OUTPUT
 	else
 	        # DEL_THRESHOLD is disabled, so we reflect this information in email and log
-		_log "INFO: Changes detected [A-$ADD_COUNT,D-$DEL_COUNT,M-$MOVE_COUNT,C-$COPY_COUNT,U-$UPDATE_COUNT] -> there are deltted files ($DEL_COUNT) but delete threshold ($DEL_THRESHOLD) is disabled. Running SYNC Command."
-		echo "Changes detected [A-$ADD_COUNT,D-$DEL_COUNT,M-$MOVE_COUNT,C-$COPY_COUNT,U-$UPDATE_COUNT] -> there are deleted files ($DEL_COUNT)  but delete threshold ($DEL_THRESHOLD) is disabled. Running SYNC Command" >> $TMP_OUTPUT
+		_log "INFO: Changes detected [A-$ADD_COUNT,D-$DEL_COUNT,M-$MOVE_COUNT,C-$COPY_COUNT,U-$UPDATE_COUNT] -> there are deleted files ($DEL_COUNT) but delete threshold ($DEL_THRESHOLD) is disabled. Running SYNC Command."
+		echo "Changes detected [A-$ADD_COUNT,D-$DEL_COUNT,M-$MOVE_COUNT,C-$COPY_COUNT,U-$UPDATE_COUNT] -> there are deleted files ($DEL_COUNT) but delete threshold ($DEL_THRESHOLD) is disabled. Running SYNC Command" >> $TMP_OUTPUT
 	fi
 	
 	# start snapraid SYNC


### PR DESCRIPTION
Hi there!

I'm using a several SnapRAID volumes as TimeCapsules for my Macs. As TimeCapsule deletes old backups when the space limit is reached, I set the deleted files threshold for the `omv-snapraid-diff` script to zero.

This is my OMV GUI config: 
![bildschirmfoto 2015-04-18 um 09 21 03](https://cloud.githubusercontent.com/assets/690188/7214518/d8e90bb6-e5af-11e4-97dd-603e5c672fcc.png)
> default = 0 to make sure no sync process is started while testing or if there are any deleted files

Unfortunately, SnapRAID did not sync last night. This was due to 735 deleted files in my TimeCapsule, even though I disabled the threshold.

Looking into `omv-snapraid-diff`, I was unable to find any check whether `DEL_THRESHOLD` is greater than zero.

This PR implements these missing conditions and also inserts a slightly modified message into the Diff-Log and -Mail.

**Normal Message:**
> Changes detected [A-5016,D-10,M-0,C-0,U-174] -> deleted files (10) is below threshold (100). Running SYNC Command

**Message when Threshold is set to 0 (disabled):**
> Changes detected [A-5016,D-10,M-0,C-0,U-174] -> there are deleted files (10) but delete threshold (0) is disabled. Running SYNC Command
