### PR TITLE
omv-snapraid-diff errors with unary operator expected

### DIFF
--- a/usr/sbin/omv-snapraid-diff
+++ b/usr/sbin/omv-snapraid-diff
@@ -369,7 +369,7 @@ _log "INFO: SUMMARY of changes since last sync:"
 _log "INFO: Added: [$ADD_COUNT] - Deleted: [$DEL_COUNT] - Moved: [$MOVE_COUNT] - Copied: [$COPY_COUNT] - Updated: [$UPDATE_COUNT]"
 
 # set pre-hash option
-if [ $(omv_config_get "/config/services/snapraid/prehash") -eq 1 ]; then
+if [[ $(omv_config_get "/config/services/snapraid/prehash") -eq 1 ]]; then
 	prehash=" --pre-hash"
 else
 	prehash=""


### PR DESCRIPTION
The script produces an error when I run manually or via cron.
`sudo /usr/sbin/omv-snapraid-diff
/usr/sbin/omv-snapraid-diff: line 372: [: -eq: unary operator expected`

`bash --version
GNU bash, version 4.3.30`