### PR TITLE
Move the list of default excludes to a config file

### DIFF
--- a/etc/default/omv_snapraid_excludes
+++ b/etc/default/omv_snapraid_excludes
@@ -1,7 +1,7 @@
-exclude *.bak
-exclude *.unrecoverable
-exclude /tmp/
 exclude lost+found/
-exclude .content
-exclude aquota.group
 exclude aquota.user
+exclude aquota.group
+exclude /tmp/
+exclude *.unrecoverable
+exclude .content
+exclude *.bak

--- a/etc/default/omv_snapraid_excludes
+++ b/etc/default/omv_snapraid_excludes
@@ -1,7 +1,7 @@
+exclude *.unrecoverable
 exclude lost+found/
 exclude aquota.user
 exclude aquota.group
 exclude /tmp/
-exclude *.unrecoverable
 exclude .content
 exclude *.bak

--- a/etc/default/omv_snapraid_excludes
+++ b/etc/default/omv_snapraid_excludes
@@ -1,0 +1,7 @@
+exclude *.bak
+exclude *.unrecoverable
+exclude /tmp/
+exclude lost+found/
+exclude .content
+exclude aquota.group
+exclude aquota.user

--- a/usr/share/openmediavault/mkconf/snapraid
+++ b/usr/share/openmediavault/mkconf/snapraid
@@ -100,17 +100,12 @@ while [ ${index} -le ${count} ]; do
     index=$(( ${index} + 1 ))
 done
 
-# Add default excludes
+# Add dynamic default excludes
 cat <<EOF >> ${SNAPRAID_CONFIG}
-exclude *.bak
-exclude *.unrecoverable
-exclude /tmp/
-exclude lost+found/
-exclude .content
-exclude aquota.group
-exclude aquota.user
 exclude ${SNAPRAID_FILENAME}*
 EOF
+# Add static default excludes
+cat /etc/default/omv_snapraid_excludes >> ${SNAPRAID_CONFIG}
 
 # Process rules
 count=$(omv_config_get_count "${RULES}")

--- a/usr/share/openmediavault/mkconf/snapraid
+++ b/usr/share/openmediavault/mkconf/snapraid
@@ -102,7 +102,7 @@ done
 
 # Add dynamic default excludes
 cat <<EOF >> ${SNAPRAID_CONFIG}
-exclude ${SNAPRAID_FILENAME}*
+exclude /${SNAPRAID_FILENAME}*
 EOF
 # Add static default excludes
 cat /etc/default/omv_snapraid_excludes >> ${SNAPRAID_CONFIG}


### PR DESCRIPTION
For #14:
* Move the list from the mkconf script
* Modify the mkconf script to use the list from this file instead (except for ${SNAPRAID_FILENAME})
* Reorder the list (snapraid related, fs/sys related, user related)
* Only exclude the ${SNAPRAID_FILENAME}* (snapraid.conf*) in the root of the drive, user might have this file elsewhere
  